### PR TITLE
Allow botanist flag names in species editor

### DIFF
--- a/bauble/plugins/abcd/__init__.py
+++ b/bauble/plugins/abcd/__init__.py
@@ -186,7 +186,7 @@ class ABCDAdapter(object):
     def get_IdentificationQualifier(self):
         pass
     
-    def get_IdentiificationQualifierRank(self):
+    def get_IdentificationQualifierRank(self):
         pass
 
     def get_InformalNameString(self):

--- a/bauble/plugins/abcd/__init__.py
+++ b/bauble/plugins/abcd/__init__.py
@@ -177,6 +177,9 @@ class ABCDAdapter(object):
     def get_InfraspecificEpithet(self):
         pass
     
+    def get_CultivarName(self):
+        pass
+    
     def get_IdentificationQualifier(self):
         pass
     
@@ -276,6 +279,9 @@ def create_abcd(decorated_objects, authors=True, validate=True):
                         text=obj.get_InfraspecificEpithet())
             ABCDElement(botanical, 'Rank',
                         text=obj.get_InfraspecificRank())
+        if obj.get_CultivarName():
+            ABCDElement(botanical, 'CultivarName',
+                        text=obj.get_CultivarName())
         author_team = obj.get_AuthorTeam()
         if author_team is not None:
             ABCDElement(botanical, 'AuthorTeam', text=author_team)

--- a/bauble/plugins/abcd/__init__.py
+++ b/bauble/plugins/abcd/__init__.py
@@ -176,6 +176,12 @@ class ABCDAdapter(object):
 
     def get_InfraspecificEpithet(self):
         pass
+    
+    def get_IdentificationQualifier(self):
+        pass
+    
+    def get_IdentiificationQualifierRank(self):
+        pass
 
     def get_InformalNameString(self):
         """
@@ -285,7 +291,10 @@ def create_abcd(decorated_objects, authors=True, validate=True):
             taxon_identified = ABCDElement(result, 'TaxonIdentified')
             ABCDElement(taxon_identified, 'InformalNameString',
                         text=vernacular_name)
-
+        if obj.get_IdentificationQualifier():
+            ABCDElement(scientific_name, 'IdentificationQualifier', 
+                        text=obj.get_IdentificationQualifier(), 
+                        attrib={'insertionpoint': obj.get_IdentificationQualifierRank()})
         # add all the extra non standard elements
         obj.extra_elements(unit)
         # TODO: handle verifiers/identifiers

--- a/bauble/plugins/abcd/__init__.py
+++ b/bauble/plugins/abcd/__init__.py
@@ -179,7 +179,10 @@ class ABCDAdapter(object):
     
     def get_CultivarName(self):
         pass
-    
+
+    def get_HybridFlag (self):
+        pass    
+
     def get_IdentificationQualifier(self):
         pass
     
@@ -279,6 +282,8 @@ def create_abcd(decorated_objects, authors=True, validate=True):
                         text=obj.get_InfraspecificEpithet())
             ABCDElement(botanical, 'Rank',
                         text=obj.get_InfraspecificRank())
+        if obj.get_HybridFlag():
+            ABCDElement(botanical, 'HybridFlag', text=obj.get_HybridFlag())
         if obj.get_CultivarName():
             ABCDElement(botanical, 'CultivarName',
                         text=obj.get_CultivarName())

--- a/bauble/plugins/plants/species_editor.py
+++ b/bauble/plugins/plants/species_editor.py
@@ -403,6 +403,15 @@ class SpeciesEditorPresenter(editor.GenericEditorPresenter):
         if text.count(u'*'):
             self.species_space = True
             text = text.replace(u'*', u" × ")
+            # allow botanist flags for unnamed species(e.g. 'sp. nov.' 
+            # 'sp. (OrmeauL.H.Bird AQ435851)') - see ITF2 - Species Epithet: 
+            # Rule of information 1.2
+        if text.count(u'sp.'):
+            self.species_space = True
+            # allow descriptive botanist flags e.g. 'caerulea (Finch Hatton)' 
+            # (although not strictly ITF2 compliant the practice is in common use)
+        if text.count(u'('):
+            self.species_space = True
         if self.species_space is False:
             text = text.replace(' ', '')
         if text != '':

--- a/bauble/plugins/plants/species_editor.py
+++ b/bauble/plugins/plants/species_editor.py
@@ -403,15 +403,18 @@ class SpeciesEditorPresenter(editor.GenericEditorPresenter):
         if text.count(u'*'):
             self.species_space = True
             text = text.replace(u'*', u" × ")
-            # allow botanist flags for unnamed species(e.g. 'sp. nov.' 
-            # 'sp. (OrmeauL.H.Bird AQ435851)') - see ITF2 - Species Epithet: 
-            # Rule of information 1.2
+
+        # allow botanist flags for unnamed species(e.g. 'sp. nov.' 
+        # 'sp. (OrmeauL.H.Bird AQ435851)') - see ITF2 - Species Epithet: 
+        # Rule of information 1.2
         if text.count(u'sp.'):
             self.species_space = True
-            # allow descriptive botanist flags e.g. 'caerulea (Finch Hatton)' 
-            # (although not strictly ITF2 compliant the practice is in common use)
+
+        # allow descriptive botanist flags e.g. 'caerulea (Finch Hatton)' 
+        # (although not strictly ITF2 compliant the practice is in common use)
         if text.count(u'('):
             self.species_space = True
+
         if self.species_space is False:
             text = text.replace(' ', '')
         if text != '':

--- a/bauble/plugins/report/xsl/__init__.py
+++ b/bauble/plugins/report/xsl/__init__.py
@@ -160,6 +160,12 @@ class SpeciesABCDAdapter(ABCDAdapter):
     def get_CultivarName(self):
         return utils.xml_safe(str(self.species.cultivar_epithet))
 
+    def get_HybridFlag(self):
+        if self.species.hybrid is True:
+            return utils.xml_safe(str(self.species.hybrid_char))
+        else:
+            return None
+
     def get_InformalNameString(self):
         vernacular_name = self.species.default_vernacular_name
         if vernacular_name is None:

--- a/bauble/plugins/report/xsl/__init__.py
+++ b/bauble/plugins/report/xsl/__init__.py
@@ -202,7 +202,21 @@ class AccessionABCDAdapter(SpeciesABCDAdapter):
     def get_FullScientificNameString(self, authors=True):
         s = self.accession.species_str(authors=authors, markup=False)
         return utils.xml_safe(s)
-
+    
+    def get_IdentificationQualifier(self):
+        idqual=self.accession.id_qual
+        if idqual is None:
+            return None
+        else:
+            return utils.xml_safe(idqual)
+        
+    def get_IdentificationQualifierRank(self):
+        idqrank=self.accession.id_qual_rank
+        if idqrank is None:
+            return None
+        else:
+            return utils.xml_safe(idqrank)
+        
     def get_DateLastEdited(self):
         return utils.xml_safe(self.accession._last_updated.isoformat())
 

--- a/bauble/plugins/report/xsl/__init__.py
+++ b/bauble/plugins/report/xsl/__init__.py
@@ -156,6 +156,9 @@ class SpeciesABCDAdapter(ABCDAdapter):
 
     def get_InfraspecificEpithet(self):
         return utils.xml_safe(str(self.species.infraspecific_epithet))
+    
+    def get_CultivarName(self):
+        return utils.xml_safe(str(self.species.cultivar_epithet))
 
     def get_InformalNameString(self):
         vernacular_name = self.species.default_vernacular_name


### PR DESCRIPTION
@mfrasca What do you think of this approach?  Its one way of allow the spaces required for the botanist flag names we use.  Looking through all the examples I have they either have `sp.` or brackets so its still fairly strict and would still prevent the spaces by mistake issue. (Also, I've heavily commented the lines so it is obvious to anyone in future). 