### PR TITLE
Appveyor nsis py2exe build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,42 @@
+image: Visual Studio 2017
+
+environment:
+    PYTHON_HOME: 'C:/Python27'
+
+branches:
+  only:
+    - ghini-1.0
+
+install:
+  - set PATH=%PYTHON_HOME%;%PYTHON_HOME%\Scripts;%PATH%;C:\Program Files (x86)\NSIS\Bin
+  - ps: if (-not (Test-Path pygtk-all-in-one-2.24.2.win32-py2.7.msi)) { Start-FileDownload "https://ftp.gnome.org/pub/GNOME/binaries/win32/pygtk/2.24/pygtk-all-in-one-2.24.2.win32-py2.7.msi" }
+  - ps: Get-FileHash pygtk-all-in-one-2.24.2.win32-py2.7.msi -Algorithm MD5 # 4bddf847f81d8de2d73048b113da3dd5
+  - 'msiexec /i pygtk-all-in-one-2.24.2.win32-py2.7.msi /qn /norestart /log pygtk-install.log TARGETDIR=C:\Python27 ALLUSERS=1'
+  - 'pip install py2exe_py2'
+  - 'pip install psycopg2'
+  - 'pip install pygments'
+
+build_script:
+  - 'mkdir dist'
+  - 'pip install .'
+  - 'python setup.py py2exe'
+  - 'python setup.py nsis'
+
+cache:
+  - pygtk-all-in-one-2.24.2.win32-py2.7.msi
+
+artifacts:
+  - path: dist/ghini.desktop-*-setup.exe
+
+test: off
+
+deploy:
+  release: 'v1.0.87' # :bump
+  description: ''
+  provider: GitHub
+  auth_token:
+    secure: # see: https://www.appveyor.com/docs/how-to/git-push/#creating-github-personal-access-token
+  draft: false
+  prerelease: false
+  # on:
+  #   appveyor_repo_tag: true        # deploy on tag push only

--- a/scripts/build-multiuser.nsi
+++ b/scripts/build-multiuser.nsi
@@ -49,9 +49,9 @@
 ; Inetc (http://nsis.sourceforge.net/Inetc_plug-in)
 ; MD5 (http://nsis.sourceforge.net/MD5_plugin)
 ;---
-!addplugindir /x86-ansi "..\data\nsis\Plugins\x86-ansi\"
-!addplugindir /x86-unicode "..\data\nsis\Plugins\x86-unicode\"
-!addincludedir "..\data\nsis\Include\"
+!addplugindir /x86-ansi "..\nsis\Plugins\x86-ansi\"
+!addplugindir /x86-unicode "..\nsis\Plugins\x86-unicode\"
+!addincludedir "..\nsis\Include\"
 
 ;------------------------------
 ;  GENERAL

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -144,6 +144,8 @@ bump_file(os.path.join(root_of_clone(), 'packages/builddeb.sh'), rx)
 rx = "(^version=)[0-9]*\.[0-9]*\.[0-9]*(.*?%s.*$)" % bump_tag
 bump_file(os.path.join(root_of_clone(), 'scripts/installer.cfg'), rx)
 
+rx = "(^  release: \'v).*?\..*?\..*?(\'.*?%s.*?$)" % (bump_tag)
+bump_file(os.path.join(root_of_clone(), '.appveyor.yml'), rx)
 # TODO: commit the changes
 print
 print 'git commit -m "bumping_to_%s" bauble/version.py doc/conf.py'\


### PR DESCRIPTION
If you are still interested something like this should work to build the windows installer without any need for you to have or use windows (I'd still advocate testing in windows after any major changes). You'll need to add the GitHub authentication token of course (and add a copy of .appveyor.yml to each branch).

See results: builds [here](https://ci.appveyor.com/project/RoDuth/ghini-desktop/build/1.0.13) and deployed artifacts in [releases](https://github.com/RoDuth/ghini.desktop/releases)

I'm sure it could do with furthur refining...

(note minor build-multiuser.nsi changes)
